### PR TITLE
bug 5.2. -- natural embedding 

### DIFF
--- a/latex/lecture_notes.tex
+++ b/latex/lecture_notes.tex
@@ -2478,7 +2478,7 @@ over some index set $I$,
 then there is a natural embedding of $\mathfrak{A}$ into the ultrapower $\prod_U \mathfrak{A}$. 
 This embedding is denoted $j_U : A \ra \prod_U A$, and is defined as follows: For all 
 $a \in A$, let $f_a : I \ra A$ be the constant map taking value $a$, i.e., $f_a(i) = a$ for 
-all $i \in I$. Then set $j_U(a) = [a]_U$.
+all $i \in I$. Then set $j_U(a) = [f_a]_U$.
 
 \begin{exercise}
   Suppose that $\mc{L}$ is a first-order language, $\mathfrak{A}$ is an $\mc{L}$-structure, 


### PR DESCRIPTION
mappin is into some equivalence class of functions, not elements